### PR TITLE
Fix typo in a class name to match the current naming in the library

### DIFF
--- a/src/main/java/net/opacapp/sample/libopacgradle/HelloOpac.java
+++ b/src/main/java/net/opacapp/sample/libopacgradle/HelloOpac.java
@@ -2,7 +2,7 @@ package net.opacapp.sample.libopacgradle;
 
 import de.geeksfactory.opacclient.OpacApiFactory;
 import de.geeksfactory.opacclient.apis.OpacApi;
-import de.geeksfactory.opacclient.objects.DetailledItem;
+import de.geeksfactory.opacclient.objects.DetailedItem;
 import de.geeksfactory.opacclient.objects.Library;
 import de.geeksfactory.opacclient.objects.SearchRequestResult;
 import de.geeksfactory.opacclient.searchfields.SearchField;
@@ -42,7 +42,7 @@ public class HelloOpac {
         System.out.println("First match: " + searchRequestResult.getResults().get(0).toString());
 
         System.out.println("Fetching details for the first result...");
-        DetailledItem detailledItem = api.getResult(0);
-        System.out.println("Got details: " + detailledItem.toString());
+        DetailedItem detailedItem = api.getResult(0);
+        System.out.println("Got details: " + detailedItem.toString());
     }
 }


### PR DESCRIPTION
See [this PR](https://github.com/rockydcoder/opacclient/commit/17f44efa110ff5a18d725c1c4d4a790fcea5d4b1) for more details.